### PR TITLE
Chore: update Group schema to include all keys from MS

### DIFF
--- a/models/group.model.ts
+++ b/models/group.model.ts
@@ -1,4 +1,4 @@
-import mongoose from "mongoose";
+import mongoose, { Schema } from "mongoose";
 
 export const groupSchema = new mongoose.Schema({
   id: String,
@@ -8,6 +8,33 @@ export const groupSchema = new mongoose.Schema({
   mailNickname: String,
   mailEnabled: Boolean,
   groupTypes: [String],
+  deletedDateTime: String,
+  classification: Schema.Types.Mixed,
+  createdDateTime: String,
+  creationOptions: [Schema.Types.Mixed],
+  expirationDateTime: String,
+  isAssignableToRole: Boolean,
+  mail: Schema.Types.Mixed,
+  membershipRule: Schema.Types.Mixed,
+  membershipRuleProcessingState: Schema.Types.Mixed,
+  onPremisesDomainName: String,
+  onPremisesLastSyncDateTime: String,
+  onPremisesNetBiosName: String,
+  onPremisesSamAccountName: String,
+  onPremisesSecurityIdentifier: String,
+  onPremisesSyncEnabled: Boolean,
+  preferredDataLocation: String,
+  preferredLanguage: String,
+  proxyAddresses: [Schema.Types.Mixed],
+  renewedDateTime: String,
+  resourceBehaviorOptions: [Schema.Types.Mixed],
+  resourceProvisioningOptions: [Schema.Types.Mixed],
+  securityIdentifier: String,
+  theme: Schema.Types.Mixed,
+  uniqueName: String,
+  visibility: String,
+  onPremisesProvisioningErrors: [Schema.Types.Mixed],
+  serviceProvisioningErrors: [Schema.Types.Mixed],
 });
 
 export const Group = mongoose.model("Group", groupSchema);

--- a/services/group.service.ts
+++ b/services/group.service.ts
@@ -53,10 +53,7 @@ export const createIfNotExistSecurityGroups: ({
       const existingGroup = await Group.findOne({ id: group.id });
       if (!existingGroup) {
         const newGroup = new Group({
-          id: group.id,
-          displayName: group.displayName,
-          mailEnabled: group.mailEnabled,
-          securityEnabled: group.securityEnabled,
+          ...group,
         });
         await newGroup.save();
 
@@ -90,11 +87,7 @@ export const upsertSecurityGroups: ({
     for (let group of securityGroups) {
       const query = { id: group.id };
       const update = {
-        displayName: group.displayName,
-        description: group.description,
-        mailEnabled: group.mailEnabled,
-        securityEnabled: group.securityEnabled,
-        createdDateTime: group.createdDateTime,
+        ...group,
       };
       await Group.updateOne(query, update, options);
     }


### PR DESCRIPTION
Context:
Previously, the entire group object was not saved. Only the key-value pairs that identified the `Group` as a `SecurityGroup` was saved. However, saving the entire object would not be too complex. Although, it does raise some questions on whether the entire group object is required as it looks to be quite the bloat per document.

Implementation:
- updated mongoose schema
- passed in whole `...group` key-value pairs   