### PR TITLE
Chore: refactor upsertSecurityGroups to use bulkWrite

### DIFF
--- a/services/group.service.ts
+++ b/services/group.service.ts
@@ -82,8 +82,6 @@ export const upsertSecurityGroups: ({
   securityGroups: Group[];
 }) => void = async ({ securityGroups }) => {
   try {
-    const options = { upsert: true };
-
     const securityGroupUpdates: {
       updateOne: {
         filter: {

--- a/services/group.service.ts
+++ b/services/group.service.ts
@@ -84,13 +84,23 @@ export const upsertSecurityGroups: ({
   try {
     const options = { upsert: true };
 
-    for (let group of securityGroups) {
-      const query = { id: group.id };
-      const update = {
-        ...group,
+    const securityGroupUpdates: {
+      updateOne: {
+        filter: {
+          id: string;
+        };
+        update: Group;
+        upsert: boolean;
       };
-      await Group.updateOne(query, update, options);
-    }
+    }[] = securityGroups.map((securityGroup: Group) => ({
+      updateOne: {
+        filter: { id: securityGroup.id },
+        update: securityGroup,
+        upsert: true,
+      },
+    }));
+
+    await Group.bulkWrite(securityGroupUpdates);
     pinoLogger.logger.debug("Groups have been updated/created");
   } catch (err: any) {
     pinoLogger.logger.debug({ err }, "Error upserting security groups");


### PR DESCRIPTION
Context:
Previous implementation was using `updateOne()` within each loop. This is more costly as it adds overhead and `bulkWrite` is, in general, [faster than sending multiple independent operations](https://mongoosejs.com/docs/api/model.html#Model.bulkWrite()). This provides motivation to improve on the implementation.

Implementation:
- use `bulkWrite()` instead
- use `.map()` to create the operations for `bulkWrite`